### PR TITLE
feat: add manifest entry for the manifest itself and use as global update throttle

### DIFF
--- a/.github/workflows/scheduled-sync.yml
+++ b/.github/workflows/scheduled-sync.yml
@@ -4,7 +4,7 @@ name: Sync Data on Schedule
 
 on:
   schedule:
-  - cron: '0 */12 * * *'
+  - cron: '17 * * * *'
   workflow_dispatch:
 
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 
 .PHONY: build
 
-start-development: build
+start-development dev: build
 	@ echo "Starting development environment..."
 
 	docker run \

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3f685da5f906721263906b6e388eec69ab9c2547222ce938161089a68c19abf
-size 13454
+oid sha256:814c49d783178cd30544e5cb0a580ce198f0d5e80d52b17f6d2638a332aec6a3
+size 13838


### PR DESCRIPTION
This MR is the first step of solving this issue:
https://github.com/open-space-collective/open-space-toolkit-physics/issues/178

Local instances of OSTk have no concept of when they can expect new data on the OSTk Data remote and so are currently over-fetching. This MR adds an entry to the manifest for itself. This is primarily to allow local OSTk instances to check the `next_update_check` of this entry to understand when the remote plans on checking for new data, and in turn understanding when they should next check the remote for new data.

It also changes the data fetching logic slightly to use the manifest `next_update_check` as a global throttle. i.e. we early exit if it has not elapsed. This global throttle was previously hard-coded in github actions to 12 hours. The actions pipeline frequency has been increased to 1 hour, with the understanding that the process will exit early if the manifest frequency has not elapsed.