### PR TITLE
feat: fetch latest eop every 3 days

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -277,7 +277,7 @@
         ],
         "last_update": "2025-11-12T18:28:46.109054",
         "next_update_check": "2026-02-12T06:28:46.109119",
-        "check_frequency": "3 months"
+        "check_frequency": "3 days"
     },
     "earth_assoc_itrf93.tf": {
         "path": "environment/ephemeris/spice",

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -276,7 +276,7 @@
             }
         ],
         "last_update": "2025-11-12T18:28:46.109054",
-        "next_update_check": "2026-02-12T06:28:46.109119",
+        "next_update_check": "2025-12-14T06:28:46.109119",
         "check_frequency": "3 days"
     },
     "earth_assoc_itrf93.tf": {


### PR DESCRIPTION
Since the latest EOP files are updated atleast bi-weekly, updating the fetch time to every 3 days.

Reference: https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/aareadme.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated check frequency for high-precision earth data from 3 months to 3 days.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->